### PR TITLE
Integrar @vercel/analytics para seguimiento de visitas

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import ScrollReset from '../components/ScrollReset';
 import { PreferencesProvider } from '../context/PreferencesContext';
+import { Analytics } from '@vercel/analytics/react';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
 
@@ -47,6 +48,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <PreferencesProvider>
           <ScrollReset />
           {children}
+          <Analytics />
         </PreferencesProvider>
       </body>
     </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emailjs/browser": "^4.4.1",
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/forms": "^0.5.10",
+        "@vercel/analytics": "^1.5.0",
         "emailjs-com": "^3.2.0",
         "framer-motion": "^12.7.4",
         "keen-slider": "^6.8.6",
@@ -1133,6 +1134,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@emailjs/browser": "^4.4.1",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.10",
+    "@vercel/analytics": "^1.5.0",
     "emailjs-com": "^3.2.0",
     "framer-motion": "^12.7.4",
     "keen-slider": "^6.8.6",


### PR DESCRIPTION
Se integró el paquete @vercel/analytics al layout principal del proyecto para habilitar el seguimiento de visitas y vistas por página de forma sencilla y sin cookies.
Esto permitirá tener una métrica clara del tráfico recibido en el portfolio, especialmente útil durante la etapa de búsqueda laboral.

Cambios realizados:

Instalación de @vercel/analytics.

Importación y render del componente <Analytics /> dentro de RootLayout.